### PR TITLE
Create a plotioda executable that generates specified plots

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ packages = find_namespace:
 python_requires = >= 3.6
 setup_requires =
   setuptools
+scripts =
+  src/plotioda/bin/plotioda
 install_requires =
   numpy
   scipy

--- a/src/plotioda/bin/plotioda
+++ b/src/plotioda/bin/plotioda
@@ -1,18 +1,38 @@
 #!/usr/bin/env python3
 # plotioda executable script
 import click
-import plotioda
+import matplotlib
+matplotlib.use('agg')
+import plotioda.utils as piutils
+import plotioda.plots as piplots
+import plotioda.configuration as piconfig
+import plotioda.io as io
 
 @click.command()
 @click.argument('yaml', type=click.Path(exists=True))
 def run_plotioda(yaml):
     """
     High level function that calls plotioda functions to produce figures.
-    
+
     Args:
         yaml: (path to YAML input configuration)
     """
-    print(yaml)
+    yamlfile = piutils.get_full_path(yaml)
+
+    # get configuration from YAML
+    config = piconfig.get_config(yamlfile)
+
+    # get IODA file path and list of plots from YAML
+    iodafile = piutils.get_full_path(config['ioda file'])
+    all_plots = config['plots']
+
+    # open up the obs space
+    obsspace = io.IODA(iodafile)
+
+    # loop through specified plots
+    for plot in all_plots:
+        myfig = piplots.gen_figure(plot, obsspace)
+        myfig.savefig(piutils.get_full_path(plot['outfile']))
 
 if __name__ == '__main__':
     run_plotioda()

--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -32,7 +32,6 @@ def _map_scatter(plot, obsspace):
     # plot a variable on a map
     # get map dataframe
     df = _gen_map_df(plot, obsspace)
-    print(df)
 
     # define map domain/projection based off of YAML
     domain = Domain(plot.get('domain', 'global'))


### PR DESCRIPTION
The `plotioda` executable takes an argument as input: path to a YAML file that will generate plots (currently just points on a map) for the specified IODA file, variable(s), etc.

The next step will be 'installing' this on Hera, creating a basic set of instructions, and testing it out with Lua modules.