### PR TITLE
Bugfix for reading latitudes and longitudes instead of latitudes twice

### DIFF
--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -82,7 +82,7 @@ def _gen_map_df(plot, obsspace):
     # grab lat, lon, and requested variable
     df_dict = {}
     df_dict['latitude'] = obsspace.get_var('latitude', 'MetaData')
-    df_dict['longitude'] = obsspace.get_var('latitude', 'MetaData')
+    df_dict['longitude'] = obsspace.get_var('longitude', 'MetaData')
     data = obsspace.get_var(plot['variable'], plot['group'])
     if plot['variable'] == 'brightness_temperature' and 'channel' in plot:
         # this is getting a brightness temperature channel


### PR DESCRIPTION
Title says it all, had a typo and wasn't grabbing both variables.