### PR TITLE
Move 'ioda file' entry to inside the plot list

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/ioda/build/lib
-        key: ioda-develop-20211119-5-${{ runner.os }}-jcsda-docker
+        key: ioda-develop-20211206-${{ runner.os }}-jcsda-docker
 
     - name: Build IODA Bundle Develop
       if: steps.cache-ioda.outputs.cache-hit != 'true'

--- a/src/plotioda/bin/plotioda
+++ b/src/plotioda/bin/plotioda
@@ -6,7 +6,6 @@ matplotlib.use('agg')
 import plotioda.utils as piutils
 import plotioda.plots as piplots
 import plotioda.configuration as piconfig
-import plotioda.io as io
 
 @click.command()
 @click.argument('yaml', type=click.Path(exists=True))
@@ -22,16 +21,12 @@ def run_plotioda(yaml):
     # get configuration from YAML
     config = piconfig.get_config(yamlfile)
 
-    # get IODA file path and list of plots from YAML
-    iodafile = piutils.get_full_path(config['ioda file'])
+    # get list of plots from YAML
     all_plots = config['plots']
-
-    # open up the obs space
-    obsspace = io.IODA(iodafile)
 
     # loop through specified plots
     for plot in all_plots:
-        myfig = piplots.gen_figure(plot, obsspace)
+        myfig = piplots.gen_figure(plot)
         myfig.savefig(piutils.get_full_path(plot['outfile']))
 
 if __name__ == '__main__':

--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -4,17 +4,18 @@ from emcpy.plots.plots import Scatter
 from emcpy.plots.map_plots import MapScatter
 from emcpy.plots import CreateMap, CreatePlot, VariableSpecs
 from emcpy.plots.map_tools import Domain, MapProjection
+import plotioda.utils as piutils
+import plotioda.io as io
 
 __all__ = ['gen_figure']
 
 
-def gen_figure(plot, obsspace):
+def gen_figure(plot):
     """
     factory to generate figure depending on type of plot
 
     Args:
         plot: dictionary containing configuration
-        obsspace: IODA Python ObsSpace object
 
     Returns:
         fig: matplotlib figure object
@@ -23,13 +24,19 @@ def gen_figure(plot, obsspace):
         'map_scatter': _map_scatter,
     }
 
-    fig = plot_types[plot['type']](plot, obsspace)
+    fig = plot_types[plot['type']](plot)
 
     return fig
 
 
-def _map_scatter(plot, obsspace):
+def _map_scatter(plot):
     # plot a variable on a map
+    # get IODA file path
+    iodafile = piutils.get_full_path(plot['ioda file'])
+
+    # open up the obsspace
+    obsspace = io.IODA(iodafile)
+
     # get map dataframe
     df = _gen_map_df(plot, obsspace)
 
@@ -75,6 +82,7 @@ def _map_scatter(plot, obsspace):
         }
         mymap.add_stats_dict(stats_dict=stats_dict)
 
+    del obsspace
     return mymap.return_figure()
 
 

--- a/src/tests/inputs/test_plot.yaml
+++ b/src/tests/inputs/test_plot.yaml
@@ -1,12 +1,12 @@
-ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
 plots:
 - type: map_scatter
   domain: global
+  ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
   variable: brightness_temperature
   group: ObsValue
   channel: 3
   stats: true
-  outfile: ./src/tests/amsua_aqua_ch3_obs_global.png
+  outfile: ./amsua_aqua_ch3_obs_global.png
   title: 'AMSU-A Aqua Brightness Temperature Ch. 3'
   cycle string: '2018041500'
   colorbar label: 'brightness temperature (K)'

--- a/src/tests/test_plotioda.py
+++ b/src/tests/test_plotioda.py
@@ -20,7 +20,6 @@ def test_plotioda_full():
 
     # this test assumes only one plot will be generated
     # first make sure the YAML is as expected
-    iodafile = piutils.get_full_path(config['ioda file'])
     all_plots = config['plots']
     if len(all_plots) != 1:
         raise ValueError("YAML issue: total number of all plots != 1")
@@ -32,6 +31,7 @@ def test_plotioda_full():
             raise ValueError("YAML issue: channel should be 3")
         if not plot['stats']:
             raise ValueError("YAML issue: stats should be true")
+        iodafile = piutils.get_full_path(plot['ioda file'])
         # now grab the necessary data
         obsspace = io.IODA(iodafile, name='Test Obs Space')
         # call the factory and generate the plot based on the config

--- a/src/tests/test_plotioda.py
+++ b/src/tests/test_plotioda.py
@@ -1,6 +1,5 @@
 import matplotlib
 matplotlib.use('agg')
-import plotioda.io as io
 import plotioda.configuration as piconfig
 import plotioda.utils as piutils
 import plotioda.plots as piplots
@@ -31,9 +30,6 @@ def test_plotioda_full():
             raise ValueError("YAML issue: channel should be 3")
         if not plot['stats']:
             raise ValueError("YAML issue: stats should be true")
-        iodafile = piutils.get_full_path(plot['ioda file'])
-        # now grab the necessary data
-        obsspace = io.IODA(iodafile, name='Test Obs Space')
         # call the factory and generate the plot based on the config
-        myfig = piplots.gen_figure(plot, obsspace)
+        myfig = piplots.gen_figure(plot)
         myfig.savefig(piutils.get_full_path(plot['outfile']))

--- a/src/tests/test_plotioda.py
+++ b/src/tests/test_plotioda.py
@@ -32,4 +32,5 @@ def test_plotioda_full():
             raise ValueError("YAML issue: stats should be true")
         # call the factory and generate the plot based on the config
         myfig = piplots.gen_figure(plot)
-        myfig.savefig(piutils.get_full_path(plot['outfile']))
+        myfig.savefig(piutils.get_full_path(plot['outfile']),
+                      bbox_inches='tight', pad_inches=0.1)


### PR DESCRIPTION
This is so that each plot can potentially have a different input file. Also allows for a future capability where a plot type (scatter or difference) can read in 2 variables from different files.