### PR TITLE
Make more things configurable through YAML

### DIFF
--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -50,21 +50,28 @@ def _map_scatter(plot):
 
     # generate data to plot and set plotting attributes
     plotobj = MapScatter(df['latitude'], df['longitude'], df['variable'])
-    for attr in ['cmap', 'vmin', 'vmax']:
+
+    # set defaults for plot if specified in the YAML
+    for attr in dir(plotobj):
         if attr in plot:
             setattr(plotobj, attr, plot[attr])
 
     # draw data on map
     mymap.draw_data([plotobj])
 
-    # add titles, color bar, etc.
-    mymap.add_colorbar(label=plot.get('colorbar label', ''),
-                       label_fontsize=12, extend='neither')
-    mymap.add_title(label=plot.get('title', ''),
-                    loc='left', fontsize=12)
-    mymap.add_title(label=plot.get('cycle string', ''),
-                    loc='right', fontsize=12,
-                    fontweight='semibold')
+    # add colorbar if requested
+    if 'colorbar' in plot:
+        colorbar = plot['colorbar']
+        mymap.add_colorbar(label=colorbar.get('label', ''),
+                           label_fontsize=colorbar.get('fontsize', 12),
+                           extend='neither')
+    if 'titles' in plot:
+        titles = plot['titles']
+        for title in titles:
+            mymap.add_title(label=title.get('string', ''),
+                            loc=title.get('loc', 'left'),
+                            fontsize=title.get('fontsize', 12),
+                            fontweight=title.get('fontweight', 'normal'))
     mymap.add_xlabel(xlabel='Longitude')
     mymap.add_ylabel(ylabel='Latitude')
 

--- a/src/tests/inputs/test_plot.yaml
+++ b/src/tests/inputs/test_plot.yaml
@@ -7,6 +7,10 @@ plots:
   channel: 3
   stats: true
   outfile: ./amsua_aqua_ch3_obs_global.png
-  title: 'AMSU-A Aqua Brightness Temperature Ch. 3'
-  cycle string: '2018041500'
-  colorbar label: 'brightness temperature (K)'
+  titles:
+  - string: 'AMSU-A Aqua Brightness Temperature Ch. 3'
+  - string: '2018041500'
+    loc: 'right'
+    fontweight: 'semibold'
+  colorbar:
+    label: 'brightness temperature (K)'

--- a/src/tests/inputs/test_plot.yaml
+++ b/src/tests/inputs/test_plot.yaml
@@ -6,6 +6,9 @@ plots:
   group: ObsValue
   channel: 3
   stats: true
+  cmap: 'jet'
+  vmin: 220
+  vmax: 290
   outfile: ./amsua_aqua_ch3_obs_global.png
   titles:
   - string: 'AMSU-A Aqua Brightness Temperature Ch. 3'


### PR DESCRIPTION
This PR allows for all of the `plotobj` attributes to be set through YAML (vmax, cmap, etc.). 

It also allows for greater flexibility in specification of titles and the colorbar.

Test YAML is updated accordingly.