### PR TITLE
Add basic scatter plot capability

### DIFF
--- a/src/plotioda/bin/plotioda
+++ b/src/plotioda/bin/plotioda
@@ -27,7 +27,8 @@ def run_plotioda(yaml):
     # loop through specified plots
     for plot in all_plots:
         myfig = piplots.gen_figure(plot)
-        myfig.savefig(piutils.get_full_path(plot['outfile']))
+        myfig.savefig(piutils.get_full_path(plot['outfile']),
+                      bbox_inches='tight', pad_inches=0.1)
 
 if __name__ == '__main__':
     run_plotioda()

--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -22,11 +22,20 @@ def gen_figure(plot):
     """
     plot_types = {
         'map_scatter': _map_scatter,
+        'scatter': _scatter,
     }
 
     fig = plot_types[plot['type']](plot)
 
     return fig
+
+
+def _scatter(plot):
+    # create a scatter plot
+    # get config for x
+    x = plot['x']
+    # get config for y
+    y = plot['y']
 
 
 def _map_scatter(plot):

--- a/src/plotioda/plots/plots.py
+++ b/src/plotioda/plots/plots.py
@@ -33,9 +33,61 @@ def gen_figure(plot):
 def _scatter(plot):
     # create a scatter plot
     # get config for x
-    x = plot['x']
+    x = plot['xdim']
+    # get requested data for x
+    iodafile = piutils.get_full_path(x['ioda file'])
+    obsspace = io.IODA(iodafile)
+    df_x = _gen_1d_df(x, obsspace)
+    del obsspace
+
     # get config for y
-    y = plot['y']
+    y = plot['ydim']
+    # get requested data for y
+    iodafile = piutils.get_full_path(y['ioda file'])
+    obsspace = io.IODA(iodafile)
+    df_y = _gen_1d_df(y, obsspace)
+    del obsspace
+
+    # set up figure
+    plotobj = Scatter(df_x['variable'].to_numpy(), df_y['variable'].to_numpy())
+
+    # add options
+    if plot.get('linear regression', False):
+        plotobj.add_linear_regression()
+    if plot.get('density scatter', False):
+        plotobj.density_scatter()
+
+    # set defaults for plot if specified in the YAML
+    for attr in dir(plotobj):
+        if attr in plot:
+            setattr(plotobj, attr, plot[attr])
+
+    # generate plot and draw data
+    myplot = CreatePlot(figsize=(10, 8))
+    myplot.draw_data([plotobj])
+
+    # add features to plot
+    if 'titles' in plot:
+        titles = plot['titles']
+        for title in titles:
+            myplot.add_title(label=title.get('string', ''),
+                             loc=title.get('loc', 'left'),
+                             fontsize=title.get('fontsize', 12),
+                             fontweight=title.get('fontweight', 'normal'))
+    myplot.add_xlabel(xlabel=x.get('label', ''))
+    myplot.add_ylabel(ylabel=y.get('label', ''))
+    if 'grid' in plot and plot['grid']:
+        myplot.add_grid(linewidth=0.5, color='grey', linestyle='--')
+    # add colorbar if requested
+    if 'colorbar' in plot:
+        colorbar = plot['colorbar']
+        myplot.add_colorbar(label=colorbar.get('label', ''),
+                            label_fontsize=colorbar.get('fontsize', 12),
+                            extend='neither')
+    if plot.get('legend', False):
+        myplot.add_legend()
+
+    return myplot.return_figure()
 
 
 def _map_scatter(plot):
@@ -107,6 +159,25 @@ def _gen_map_df(plot, obsspace):
     df_dict = {}
     df_dict['latitude'] = obsspace.get_var('latitude', 'MetaData')
     df_dict['longitude'] = obsspace.get_var('longitude', 'MetaData')
+    data = obsspace.get_var(plot['variable'], plot['group'])
+    if plot['variable'] == 'brightness_temperature' and 'channel' in plot:
+        # this is getting a brightness temperature channel
+        chanCoords = _get_indexed_channels(obsspace)
+        chanIndex = chanCoords.index(plot['channel'])
+        df_dict['variable'] = data[:, chanIndex]
+    else:
+        # just grab the standard variable
+        df_dict['variable'] = data
+    # create the dataframe
+    df = pd.DataFrame(df_dict)
+    df = df.dropna().reset_index()  # remove NaNs
+
+    return df
+
+
+def _gen_1d_df(plot, obsspace):
+    # grab requested variable
+    df_dict = {}
     data = obsspace.get_var(plot['variable'], plot['group'])
     if plot['variable'] == 'brightness_temperature' and 'channel' in plot:
         # this is getting a brightness temperature channel

--- a/src/tests/inputs/test_plot.yaml
+++ b/src/tests/inputs/test_plot.yaml
@@ -18,19 +18,22 @@ plots:
   colorbar:
     label: 'brightness temperature (K)'
 - type: scatter
-  x:
+  xdim:
     ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
     variable: brightness_temperature
     group: ObsValue
     channel: 3
     label: 'ObsValue'
-  y:
+  ydim:
     ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
     variable: brightness_temperature
     group: GsiHofX
     channel: 3
     label: 'GSI H(x)'
   outfile: ./amsua_aqua_ch3_scatter.png
+  legend: true
+  grid: true
+  linear regression: true
   titles:
   - string: 'AMSU-A Aqua Brightness Temperature Ch. 3'
   - string: '2018041500'

--- a/src/tests/inputs/test_plot.yaml
+++ b/src/tests/inputs/test_plot.yaml
@@ -17,3 +17,22 @@ plots:
     fontweight: 'semibold'
   colorbar:
     label: 'brightness temperature (K)'
+- type: scatter
+  x:
+    ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
+    variable: brightness_temperature
+    group: ObsValue
+    channel: 3
+    label: 'ObsValue'
+  y:
+    ioda file: src/tests/inputs/amsua_aqua_obs_2018041500.nc4
+    variable: brightness_temperature
+    group: GsiHofX
+    channel: 3
+    label: 'GSI H(x)'
+  outfile: ./amsua_aqua_ch3_scatter.png
+  titles:
+  - string: 'AMSU-A Aqua Brightness Temperature Ch. 3'
+  - string: '2018041500'
+    loc: 'right'
+    fontweight: 'semibold'

--- a/src/tests/test_plotioda.py
+++ b/src/tests/test_plotioda.py
@@ -20,17 +20,20 @@ def test_plotioda_full():
     # this test assumes only one plot will be generated
     # first make sure the YAML is as expected
     all_plots = config['plots']
-    if len(all_plots) != 1:
-        raise ValueError("YAML issue: total number of all plots != 1")
+    if len(all_plots) != 2:
+        raise ValueError("YAML issue: total number of all plots != 2")
+    iplot = 0
     for plot in all_plots:  # should only be one to loop through
-        # check a few variables, not all
-        if plot['type'] != 'map_scatter':
-            raise ValueError("YAML issue: type should be 'map_scatter'")
-        if plot['channel'] != 3:
-            raise ValueError("YAML issue: channel should be 3")
-        if not plot['stats']:
-            raise ValueError("YAML issue: stats should be true")
+        if iplot == 0:
+            # check a few variables, not all
+            if plot['type'] != 'map_scatter':
+                raise ValueError("YAML issue: type should be 'map_scatter'")
+            if plot['channel'] != 3:
+                raise ValueError("YAML issue: channel should be 3")
+            if not plot['stats']:
+                raise ValueError("YAML issue: stats should be true")
         # call the factory and generate the plot based on the config
         myfig = piplots.gen_figure(plot)
         myfig.savefig(piutils.get_full_path(plot['outfile']),
                       bbox_inches='tight', pad_inches=0.1)
+        iplot += 1


### PR DESCRIPTION
This PR:
1. adds support for creating scatter plots designated through YAML
2. adds the 'tight layout' so that the .png looks better.

To test in your env on Hera, after cloning:
```
export JEDI_OPT=/scratch1/NCEPDEV/jcsda/jedipara/opt/modules
module use $JEDI_OPT/modulefiles/core
module load jedi/intel-impi/2020.2
module unload intelpython
export PYTHONPATH=$PYTHONPATH:/scratch1/NCEPDEV/da/Cory.R.Martin/JEDI/stable/ioda-bundle/buildsprint/lib/python3.7/pyioda/
module use /scratch1/NCEPDEV/da/Cory.R.Martin/Modulefiles/python/
module load anaconda/kevin
module load emcpy/0.1
export PYTHONPATH=/path/to/clone/src/:$PYTHONPATH
```